### PR TITLE
Add ability to upload images via form-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Response Body
 
 # **/upload/** • POST
 
-Images will be passed along as base64 encrypted strings, checkout [this converter](https://www.base64-image.de/) as the format we are using. You can send a POST request to this route and put an image and the bucket name in the form-data. Use `file` key for the image, and `bucket` key for the bucket name.
+Images will be passed along as base64 encrypted strings, checkout [this converter](https://www.base64-image.de/) as the format we are using. You can send a POST request to this route and put an image and the bucket name in the form-data. Use `image` key for the image, and `bucket` key for the bucket name.
 
 Request Body
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Response Body
 
 # **/upload/** • POST
 
-Images will be passed along as base64 encrypted strings, checkout [this converter](https://www.base64-image.de/) as the format we are using.
+Images will be passed along as base64 encrypted strings, checkout [this converter](https://www.base64-image.de/) as the format we are using. You can send a POST request to this route and put an image and the bucket name in the form-data. Use `file` key for the image, and `bucket` key for the bucket name.
 
 Request Body
 

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import json
 
 from flask import Flask
 from flask import request
+import base64
 from utils import success_response, failure_response, upload_image_helper, remove_image_helper
 import os
 
@@ -14,15 +15,27 @@ def hello_world():
 
 
 @app.route("/upload/", methods=["POST"])
-def upload():
-    body = json.loads(request.data)
-    image_data = body.get("image")
-    bucket_name = body.get("bucket")  
-    if image_data is None:
-        return failure_response("No base64 URL to be found!")
+def upload(): 
+    body = None
+    # Check if they are using form-data or JSON body, handle accordingly
+    if request.data:
+        body = json.loads(request.data)
+        bucket_name = body.get("bucket")  
+        image_data = body.get("image")
+    else:
+        bucket_name = request.form.get("bucket")
+        print(f"bucket_name = {bucket_name}")
+        file = request.files.get("file")
+        image_data = None
+        if file:  
+            file_data = file.read()
+            image_data = base64.b64encode(file_data).decode()
+        else: 
+            return failure_response("No image file provided", 400)
+
     img_url = upload_image_helper(image_data, bucket_name)
     if img_url is None:
-        return failure_response("Could not upload image!")
+        return failure_response("Could not upload image!") 
     return success_response(img_url, 201)
 
 @app.route("/remove/", methods=["POST"])

--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ def upload():
         return success_response(img_url, 201)
     else:
         bucket_name = request.form.get("bucket")
-        file = request.files.get("file")
+        file = request.files.get("image")
         image_data = None
         if file:
             img_url = upload_image_helper(file_data=file, bucket_name=bucket_name)

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,5 @@
 import base64
 import boto3
-import datetime
 from io import BytesIO
 from mimetypes import guess_extension, guess_type
 import os
@@ -23,7 +22,9 @@ def failure_response(message, code=404):
 
 
 def upload_image_helper(image_data, bucket_name):
+    print(f"BUCKET_NAMES = {BUCKET_NAMES}")
     if bucket_name not in BUCKET_NAMES:
+        print("INVALID BUCKET")
         return None
     mime_type = guess_type(image_data)[0]
     ext = guess_extension(guess_type(image_data)[0])[1:]
@@ -36,7 +37,7 @@ def upload_image_helper(image_data, bucket_name):
     # remove header of Base64 string
     img_str = re.sub("^.*?;base64,", "", image_data)
     img_data = base64.b64decode(img_str)
-    img_filename = f"{salt}.{ext}"
+    img_filename = f"{salt}.{ext}" 
 
     session = boto3.session.Session()
     client = session.client(

--- a/utils.py
+++ b/utils.py
@@ -70,20 +70,13 @@ def upload_image_helper(bucket_name,image_data=None, file_data=None):
         aws_secret_access_key=os.environ["SPACES_SECRET_ACCESS_KEY"],
     )
     
-    if file_data:
-        client.put_object(
-            Bucket=bucket_name,
-            Key=img_filename,
-            Body=file_data.read(),
-            ACL="public-read",
-        )
-    else:
-        client.put_object(
-            Bucket=bucket_name,
-            Key=img_filename,
-            Body=BytesIO(img_bytes),
-            ACL="public-read",
-        )
+    body = file_data.read() if file_data else BytesIO(img_bytes)
+    client.put_object(
+        Bucket=bucket_name,
+        Key=img_filename,
+        Body=body,
+        ACL="public-read",
+    )
 
     img_url = f"{os.environ['SPACES_ENDPOINT_URL']}/{bucket_name}/{img_filename}"
     return img_url

--- a/utils.py
+++ b/utils.py
@@ -44,16 +44,12 @@ def upload_image_helper(bucket_name,image_data=None, file_data=None):
     if bucket_name not in BUCKET_NAMES:
         return None
     # Guess the file type, depending on whether we have image data or file data
-    if image_data:
-        mime_type = guess_type(image_data)[0]
-        ext = guess_extension(guess_type(image_data)[0])[1:]
-        if re.fullmatch(ALLOWED_MIME_TYPES_REGEX, mime_type) is None:
-            raise Exception(f"Extension {ext} not supported!")
-    else:
-        mime_type = guess_type(file_data.filename)[0]
-        ext = guess_extension(mime_type)[1:]
-        if re.fullmatch(ALLOWED_MIME_TYPES_REGEX, mime_type) is None:
-            raise Exception(f"Extension {ext} not supported!")
+    to_guess = image_data if image_data else file_data.filename
+    mime_type = guess_type(to_guess)[0]
+    ext = guess_extension(mime_type)[1:]
+    if re.fullmatch(ALLOWED_MIME_TYPES_REGEX, mime_type) is None:
+        raise Exception(f"Extension {ext} not supported!")
+
     # secure way of generating random string for image name
     salt = "".join(random.SystemRandom().choice(string.ascii_lowercase + string.digits) for _ in range(8))
     img_filename = f"{salt}.{ext}" 

--- a/utils.py
+++ b/utils.py
@@ -1,13 +1,14 @@
 import base64
-import boto3
-from io import BytesIO
-from mimetypes import guess_extension, guess_type
+import json
 import os
-from PIL import Image
 import random
 import re
 import string
-import json
+from io import BytesIO
+from mimetypes import guess_extension, guess_type
+
+import boto3
+from PIL import Image
 
 ALLOWED_MIME_TYPES_REGEX = "image/.+|application/pdf"
 BUCKET_NAMES = os.environ["BUCKET_NAMES"].split(",")
@@ -21,23 +22,48 @@ def failure_response(message, code=404):
     return json.dumps({"success": False, "error": message}), code
 
 
-def upload_image_helper(image_data, bucket_name):
-    print(f"BUCKET_NAMES = {BUCKET_NAMES}")
+def upload_image_helper(bucket_name,image_data=None, file_data=None):
+    """
+    Function that uploads image data to s3 based on the bucket name and data.
+    
+    Parameters
+    ----
+    bucket_name : str
+    The name of the bucket to place the image in
+    image_data : str | None
+    The raw base 64 passed in from the HTML post request, potentially None if
+    the client is using form-data
+    file_data: FileStore | None
+    The file from the form-data of the user's HTML request, or None if it was
+    passed in the request body instead.
+    
+    Returns
+    ----
+    The image URL associated to the image that was uploaded to s3
+    """
     if bucket_name not in BUCKET_NAMES:
-        print("INVALID BUCKET")
         return None
-    mime_type = guess_type(image_data)[0]
-    ext = guess_extension(guess_type(image_data)[0])[1:]
-    if re.fullmatch(ALLOWED_MIME_TYPES_REGEX, mime_type) is None:
-        raise Exception(f"Extension {ext} not supported!")
-
+    # Guess the file type, depending on whether we have image data or file data
+    if image_data:
+        mime_type = guess_type(image_data)[0]
+        ext = guess_extension(guess_type(image_data)[0])[1:]
+        if re.fullmatch(ALLOWED_MIME_TYPES_REGEX, mime_type) is None:
+            raise Exception(f"Extension {ext} not supported!")
+    else:
+        mime_type = guess_type(file_data.filename)[0]
+        ext = guess_extension(mime_type)[1:]
+        if re.fullmatch(ALLOWED_MIME_TYPES_REGEX, mime_type) is None:
+            raise Exception(f"Extension {ext} not supported!")
     # secure way of generating random string for image name
     salt = "".join(random.SystemRandom().choice(string.ascii_lowercase + string.digits) for _ in range(8))
-
-    # remove header of Base64 string
-    img_str = re.sub("^.*?;base64,", "", image_data)
-    img_data = base64.b64decode(img_str)
     img_filename = f"{salt}.{ext}" 
+    
+    # We won't use these if user uploaded file in form data
+    if image_data:
+        # remove header of Base64 string
+        img_str = re.sub("^.*?;base64,", "", image_data)
+        # get the decoded bytes of the base 64 image, or process FileStore object
+        img_bytes = base64.b64decode(img_str)
 
     session = boto3.session.Session()
     client = session.client(
@@ -47,13 +73,21 @@ def upload_image_helper(image_data, bucket_name):
         aws_access_key_id=os.environ["SPACES_ACCESS_KEY_ID"],
         aws_secret_access_key=os.environ["SPACES_SECRET_ACCESS_KEY"],
     )
-
-    res = client.put_object(
-        Bucket=bucket_name,
-        Key=img_filename,
-        Body=BytesIO(img_data),
-        ACL="public-read",
-    )
+    
+    if file_data:
+        client.put_object(
+            Bucket=bucket_name,
+            Key=img_filename,
+            Body=file_data.read(),
+            ACL="public-read",
+        )
+    else:
+        client.put_object(
+            Bucket=bucket_name,
+            Key=img_filename,
+            Body=BytesIO(img_bytes),
+            ACL="public-read",
+        )
 
     img_url = f"{os.environ['SPACES_ENDPOINT_URL']}/{bucket_name}/{img_filename}"
     return img_url


### PR DESCRIPTION
## Overview

Extend the upload route to accept images using form-data. 

## Changes Made

- Add `file_data` parameter for the util for updating images
- Add documentation for the `upload_image_helper` function
- Modify the original upload route to check for form-data.


## Test Coverage

I tested uploading a 24.9 MB image to the service with Postman and it worked fine. I tried uploading JPG and png image files through form data and they worked as expected. Also tested uploading images through base64 in the request body and it still worked.

## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<img width="1032" alt="image" src="https://github.com/cuappdev/upload/assets/58796478/081ed915-143d-49fa-957f-d31d8a015aae">